### PR TITLE
Always use native LZO library if it exists

### DIFF
--- a/src/main/java/com/hadoop/compression/lzo/LzoCodec.java
+++ b/src/main/java/com/hadoop/compression/lzo/LzoCodec.java
@@ -85,13 +85,11 @@ public class LzoCodec implements Configurable, CompressionCodec {
   /**
    * Check if native-lzo library is loaded and initialized.
    *
-   * @param conf configuration
    * @return <code>true</code> if native-lzo library is loaded and initialized;
    *         else <code>false</code>
    */
-  public static boolean isNativeLzoLoaded(Configuration conf) {
-    assert conf != null : "Configuration cannot be null!";
-    return nativeLzoLoaded && conf.getBoolean("hadoop.native.lib", true);
+  public static boolean isNativeLzoLoaded() {
+    return nativeLzoLoaded;
   }
 
   public static String getRevisionHash() {
@@ -114,7 +112,7 @@ public class LzoCodec implements Configurable, CompressionCodec {
   public CompressionOutputStream createOutputStream(OutputStream out,
       Compressor compressor) throws IOException {
     // Ensure native-lzo library is loaded & initialized
-    if (!isNativeLzoLoaded(conf)) {
+    if (!isNativeLzoLoaded()) {
       throw new RuntimeException("native-lzo library not available");
     }
 
@@ -151,7 +149,7 @@ public class LzoCodec implements Configurable, CompressionCodec {
   @Override
   public Class<? extends Compressor> getCompressorType() {
     // Ensure native-lzo library is loaded & initialized
-    if (!isNativeLzoLoaded(conf)) {
+    if (!isNativeLzoLoaded()) {
       throw new RuntimeException("native-lzo library not available");
     }
     return LzoCompressor.class;
@@ -161,7 +159,7 @@ public class LzoCodec implements Configurable, CompressionCodec {
   public Compressor createCompressor() {
     // Ensure native-lzo library is loaded & initialized
     assert conf != null : "Configuration cannot be null! You must call setConf() before creating a compressor.";
-    if (!isNativeLzoLoaded(conf)) {
+    if (!isNativeLzoLoaded()) {
       throw new RuntimeException("native-lzo library not available");
     }
 
@@ -179,7 +177,7 @@ public class LzoCodec implements Configurable, CompressionCodec {
       Decompressor decompressor)
   throws IOException {
     // Ensure native-lzo library is loaded & initialized
-    if (!isNativeLzoLoaded(conf)) {
+    if (!isNativeLzoLoaded()) {
       throw new RuntimeException("native-lzo library not available");
     }
     return new BlockDecompressorStream(in, decompressor,
@@ -189,7 +187,7 @@ public class LzoCodec implements Configurable, CompressionCodec {
   @Override
   public Class<? extends Decompressor> getDecompressorType() {
     // Ensure native-lzo library is loaded & initialized
-    if (!isNativeLzoLoaded(conf)) {
+    if (!isNativeLzoLoaded()) {
       throw new RuntimeException("native-lzo library not available");
     }
     return LzoDecompressor.class;
@@ -198,7 +196,7 @@ public class LzoCodec implements Configurable, CompressionCodec {
   @Override
   public Decompressor createDecompressor() {
     // Ensure native-lzo library is loaded & initialized
-    if (!isNativeLzoLoaded(conf)) {
+    if (!isNativeLzoLoaded()) {
       throw new RuntimeException("native-lzo library not available");
     }
 

--- a/src/main/java/com/hadoop/compression/lzo/LzopCodec.java
+++ b/src/main/java/com/hadoop/compression/lzo/LzopCodec.java
@@ -92,7 +92,7 @@ public class LzopCodec extends LzoCodec {
 
   public CompressionOutputStream createIndexedOutputStream(OutputStream out,
         DataOutputStream indexOut, Compressor compressor) throws IOException {
-    if (!isNativeLzoLoaded(getConf())) {
+    if (!isNativeLzoLoaded()) {
       throw new RuntimeException("native-lzo library not available");
     }
     LzoCompressor.CompressionStrategy strategy = LzoCompressor.CompressionStrategy.valueOf(
@@ -105,7 +105,7 @@ public class LzopCodec extends LzoCodec {
   public CompressionInputStream createInputStream(InputStream in,
           Decompressor decompressor) throws IOException {
     // Ensure native-lzo library is loaded & initialized
-    if (!isNativeLzoLoaded(getConf())) {
+    if (!isNativeLzoLoaded()) {
       throw new RuntimeException("native-lzo library not available");
     }
     return new LzopInputStream(in, decompressor,
@@ -152,7 +152,7 @@ public class LzopCodec extends LzoCodec {
   @Override
   public Class<? extends Decompressor> getDecompressorType() {
     // Ensure native-lzo library is loaded & initialized
-    if (!isNativeLzoLoaded(getConf())) {
+    if (!isNativeLzoLoaded()) {
       throw new RuntimeException("native-lzo library not available");
     }
     return LzopDecompressor.class;
@@ -160,7 +160,7 @@ public class LzopCodec extends LzoCodec {
 
   @Override
   public Decompressor createDecompressor() {
-    if (!isNativeLzoLoaded(getConf())) {
+    if (!isNativeLzoLoaded()) {
       throw new RuntimeException("native-lzo library not available");
     }
     return new LzopDecompressor(getConf().getInt(LZO_BUFFER_SIZE_KEY, DEFAULT_LZO_BUFFER_SIZE));


### PR DESCRIPTION
This PR updates hadoop-lzo to always use native libraries if they exist/have been loaded instead of also ensuring that the `hadoop.native.lib` is set to `true` and that the native libraries have been loaded. It seems that this configuration check is a bit of a CPU hotspot—this boolean configuration check accounts for about half the time spent in `LzoCodec#createInputStream`, `LzoDecompressor#decompress` spends about the same CPU time as `LzoCodec#createInputStream` which means that setting up the input stream for decompression takes more time than the decompression itself! I have a few CPU profiles showing this in newly started region servers that are doing lots of decompression after starting up to fill their block cache. 

In any case, since this library is built against Hadoop 3 then it should abide by this behavior anyway as [HADOOP-11627](https://issues.apache.org/jira/browse/HADOOP-11627) removed `io.native.lib.available` as a configuration key in favor of using native libraries if they exist. 